### PR TITLE
Fix bug in fontScale

### DIFF
--- a/TYPagerControllerDemo/TYPagerController/TabPager/TYTabPagerBarLayout.m
+++ b/TYPagerControllerDemo/TYPagerController/TabPager/TYTabPagerBarLayout.m
@@ -204,12 +204,12 @@
         if (fromCell) {
             fromCell.titleLabel.font = _normalTextFont;
             fromCell.titleLabel.textColor = _normalTextColor;
-            fromCell.transform = CGAffineTransformMakeScale(_selectFontScale, _selectFontScale);
+            fromCell.transform = CGAffineTransformIdentity;
         }
         if (toCell) {
             toCell.titleLabel.font = _normalTextFont;
             toCell.titleLabel.textColor = _selectedTextColor ? _selectedTextColor : _normalTextColor;
-            toCell.transform = CGAffineTransformIdentity;
+            toCell.transform = CGAffineTransformMakeScale(1/_selectFontScale,1/ _selectFontScale);
         }
     };
     if (animate) {


### PR DESCRIPTION
There is a bug in fontScale. ie:
if normal font size is 12, selected font size is 16
then the fontScale is 0.75
the result is normal font size is `0.75*12`, the selected font size is `0.75 * 16`

This pull request fix this bug