### PR TITLE
Fixed "Selected Font not working"

### DIFF
--- a/TYPagerControllerDemo/TYPagerController/TabPager/TYTabPagerBarLayout.m
+++ b/TYPagerControllerDemo/TYPagerController/TabPager/TYTabPagerBarLayout.m
@@ -207,7 +207,7 @@
             fromCell.transform = CGAffineTransformMakeScale(_selectFontScale, _selectFontScale);
         }
         if (toCell) {
-            toCell.titleLabel.font = _normalTextFont;
+            toCell.titleLabel.font = _selectedTextFont ? _selectedTextFont : _normalTextFont;
             toCell.titleLabel.textColor = _selectedTextColor ? _selectedTextColor : _normalTextColor;
             toCell.transform = CGAffineTransformIdentity;
         }


### PR DESCRIPTION
> Problem

selectedFont wasn't working.
The code was only checking **selectedFont** and sending font only the normal font

>Fix
Fixed the code by checking **selectedTextFont** and sending selectedTextFont if it exists.